### PR TITLE
Add support to read log files from docker containers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 delta.db
 deltareport
+test.db

--- a/conf.d/docker.toml
+++ b/conf.d/docker.toml
@@ -1,0 +1,7 @@
+# Container name shown in output `docker ps`
+ContainerName = "nginx"
+# ContainerNameStrict will search for exact match when set true
+ContainerNameStrict = false
+Linediff = false
+Recurse = true
+To = "admin"

--- a/config/config.go
+++ b/config/config.go
@@ -2,13 +2,15 @@ package config
 
 import (
 	"fmt"
-	"github.com/BurntSushi/toml"
-	"github.com/boltdb/bolt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strings"
 	"time"
+
+	"github.com/boltdb/bolt"
+	"github.com/jinzhu/configor"
 	"github.com/robertkrimen/otto"
 )
 
@@ -21,14 +23,18 @@ type File struct {
 	Regex      string
 	Regexp     *regexp.Regexp
 	Linediff   bool
+	// ContainerName name of docker container
+	ContainerName string
+	// ContainerNameStrict Search fo exact name
+	ContainerNameStrict bool
 }
 
 type Config struct {
-	Confdir string
-	Files   []File
+	Confdir   string
+	Files     []File
 	Scriptdir string
 
-	Queues  struct {
+	Queues struct {
 		Mail map[string]struct {
 			Beanstalkd string
 			From       string
@@ -51,16 +57,12 @@ var (
 	Hostname string
 
 	ScriptEngine *otto.Otto
-	Scripts map[string]*otto.Script
+	Scripts      map[string]*otto.Script
 )
 
 func Init(f string) error {
-	r, e := os.Open(f)
-	if e != nil {
-		return e
-	}
-	defer r.Close()
-	if _, e := toml.DecodeReader(r, &C); e != nil {
+	var e error
+	if e := configor.Load(&C, f); e != nil {
 		return fmt.Errorf("TOML: %s", e)
 	}
 	if e := loadConfDir(); e != nil {
@@ -96,17 +98,43 @@ func loadConfDir() error {
 				return nil
 			}
 
-			if strings.HasSuffix(path, ".toml") {
-				r, e := os.Open(path)
-				if e != nil {
-					return e
-				}
+			if strings.HasSuffix(path, ".toml") || strings.HasSuffix(path, ".yaml") || strings.HasSuffix(path, ".yml") {
 				var f File
-				if _, e := toml.DecodeReader(r, &f); e != nil {
-					r.Close()
-					return fmt.Errorf("TOML(%s): %s", path, e)
+				if e := configor.Load(&f, path); e != nil {
+					return fmt.Errorf("loading config (%s): %s", path, e)
 				}
-				r.Close()
+
+				// Build path for containers
+				if len(f.ContainerName) > 0 {
+					commandargs := fmt.Sprintf("name=%s", f.ContainerName)
+					if f.ContainerNameStrict {
+						commandargs = fmt.Sprintf("name=^/%s$", f.ContainerName)
+					}
+					id, e := exec.Command("docker", "ps", "--format='{{.ID}}'", "-f", commandargs).Output()
+					// Cleanup of id
+					container_id := strings.ReplaceAll(string(id), "\n", "")
+					container_id = strings.ReplaceAll(container_id, "'", "")
+
+					if e != nil || len(container_id) < 1 {
+						if Verbose {
+							fmt.Printf("can't find container %s\n", f.ContainerName)
+						}
+						return nil
+					}
+
+					lp, e := exec.Command("docker", "inspect", "--format='{{.LogPath}}'", container_id).Output()
+					logpath := strings.ReplaceAll(string(lp), "\n", "")
+					logpath = strings.ReplaceAll(logpath, "'", "")
+					if e != nil || len(string(logpath)) < 1 {
+						if Verbose {
+							fmt.Printf("can't inspect container %s\n", f.ContainerName)
+						}
+						return nil
+					}
+					if len(logpath) > 0 {
+						f.Path = string(logpath)
+					}
+				}
 				C.Files = append(C.Files, f)
 			}
 

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/mpdroog/deltareport
 go 1.13
 
 require (
-	github.com/BurntSushi/toml v0.3.1
 	github.com/boltdb/bolt v1.3.1
+	github.com/jinzhu/configor v1.2.1
 	github.com/mpdroog/beanstalkd v0.0.0-20151231090228-bf387addf002
 	github.com/robertkrimen/otto v0.0.0-20200922221731-ef014fd054ac
 	golang.org/x/sys v0.0.0-20201014080544-cc95f250f6bc // indirect

--- a/go.sum
+++ b/go.sum
@@ -2,11 +2,17 @@ github.com/BurntSushi/toml v0.3.1 h1:WXkYYl6Yr3qBf1K79EBnL4mak0OimBfB0XUf9Vl28OQ
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
 github.com/boltdb/bolt v1.3.1 h1:JQmyP4ZBrce+ZQu0dY660FMfatumYDLun9hBCUVIkF4=
 github.com/boltdb/bolt v1.3.1/go.mod h1:clJnj/oiGkjum5o1McbSZDSLxVThjynRyGBgiAx27Ps=
+github.com/jinzhu/configor v1.2.1 h1:OKk9dsR8i6HPOCZR8BcMtcEImAFjIhbJFZNyn5GCZko=
+github.com/jinzhu/configor v1.2.1/go.mod h1:nX89/MOmDba7ZX7GCyU/VIaQ2Ar2aizBl2d3JLF/rDc=
 github.com/mpdroog/beanstalkd v0.0.0-20151231090228-bf387addf002 h1:QNXRrUAScGch2v2koxvFMpobq88V7cEGvbLfHX8D+Ak=
 github.com/mpdroog/beanstalkd v0.0.0-20151231090228-bf387addf002/go.mod h1:Qnm/zq76O/pqutkxyyE4WGu30l4S/6iPUnESIDLNFFQ=
 github.com/robertkrimen/otto v0.0.0-20200922221731-ef014fd054ac h1:kYPjbEN6YPYWWHI6ky1J813KzIq/8+Wg4TO4xU7A/KU=
 github.com/robertkrimen/otto v0.0.0-20200922221731-ef014fd054ac/go.mod h1:xvqspoSXJTIpemEonrMDFq6XzwHYYgToXWj5eRX1OtY=
 golang.org/x/sys v0.0.0-20201014080544-cc95f250f6bc h1:HVFDs9bKvTxP6bh1Rj9MCSo+UmafQtI8ZWDPVwVk9g4=
 golang.org/x/sys v0.0.0-20201014080544-cc95f250f6bc/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/sourcemap.v1 v1.0.5 h1:inv58fC9f9J3TK2Y2R1NPntXEn3/wjWHkonhIUODNTI=
 gopkg.in/sourcemap.v1 v1.0.5/go.mod h1:2RlvNNSMglmRrcvhfuzp4hQHwOtjxlbjX7UPY/GXb78=
+gopkg.in/yaml.v2 v2.2.2 h1:ZCJp+EgiOT7lHqUV2J862kp8Qj64Jo6az82+3Td9dZw=
+gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/main.go
+++ b/main.go
@@ -3,11 +3,12 @@ package main
 import (
 	"flag"
 	"fmt"
+	"os"
+
 	"github.com/mpdroog/deltareport/config"
 	"github.com/mpdroog/deltareport/diff"
 	"github.com/mpdroog/deltareport/model"
 	"github.com/mpdroog/deltareport/queue"
-	"os"
 )
 
 func main() {
@@ -87,6 +88,11 @@ func main() {
 		}
 		if config.Verbose {
 			fmt.Printf("script.filtered bytes=%d\n", sumbytes)
+		}
+
+		// No scripts found so difference in sumbytes
+		if sumbytes == 0 && len(lookup) > 0 {
+			sumbytes = len(lookup)
 		}
 
 		if sumbytes > 0 {

--- a/queue/struct.go
+++ b/queue/struct.go
@@ -2,4 +2,4 @@ package queue
 
 import "fmt"
 
-var ErrNotFound = fmt.Errorf("No such queue")
+var ErrNotFound = fmt.Errorf("no such queue")


### PR DESCRIPTION
* Replaced BurntSushi/toml for jinzhu/configor to support multiple config file types
* Bugfix; symbytes was always 0 if you don't use any scripts.